### PR TITLE
GUI-Linux-dist-config add targets in package.json

### DIFF
--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -41,9 +41,28 @@
     },
     "linux": {
       "target": [
-        "deb",
-        "rpm",
-        "AppImage"
+        {
+          "target": "deb",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        {
+          "target": "rpm",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "ia32"
+          ]
+        },
+        "snap"
       ],
       "category": "Development"
     },


### PR DESCRIPTION
- Fix `package.json` config for Linux dist build:
  - Added `.snap` installer
  - Specify `x64` and `ia32` archs for targets `.deb`, `.rpm`, `.AppImage`