### PR TITLE
SPM-83 remove rewards from title and reword transaction fields

### DIFF
--- a/electron-app/src/utils/messages.js
+++ b/electron-app/src/utils/messages.js
@@ -53,17 +53,17 @@ const messages = {
       transactions: {
         title: 'Transactions',
         update: 'Update',
-        txRcv: 'Tx Received',
-        txs: 'Txs',
-        outputs: 'Outputs',
-        fees: 'Fees'
+        txRcv: 'Total Tx received',
+        txs: 'Txs in last block',
+        outputs: 'Total Outputs in last block',
+        fees: 'Total Fees in last block'
       },
       uptime: 'Up Since'
     },
     stake: {
       rewardsEarned: 'Rewards Earned',
       rewardsPending: 'Rewards Pending',
-      title: 'Stake State and Rewards',
+      title: 'Stake State',
       totalValue: 'Total Value',
       totalStake: 'Total Stake',
       update: 'Update'


### PR DESCRIPTION
- Remove rewards from stake state section title
- Change tx info fields:
  - 'Tx Received' to 'Total Tx received'
  - 'Txs' to 'Txs in last block'
  - 'Outputs' to 'Total Outputs in last block'
  - 'Fees' to 'Total Fees in last block'