### PR TITLE
SPM-86 - Limit fragment and leader logs

### DIFF
--- a/electron-app/src/components/molecules/ReportTool/FragmentLogs/FragmentLogs.jsx
+++ b/electron-app/src/components/molecules/ReportTool/FragmentLogs/FragmentLogs.jsx
@@ -10,6 +10,7 @@ import { formatDateTimeWithComma } from '../../../../utils/formatters';
 
 const FragmentLogs = ({ nodeAddress }) => {
   const PAGE_SIZE = 8;
+  const TABLE_SIZE = 200;
 
   const [fragmentLogs, setFragmentLogs] = useState();
   const [inputFragmentId, setInputFragmentId] = useState();
@@ -42,7 +43,14 @@ const FragmentLogs = ({ nodeAddress }) => {
             fragment => fragment.fragment_id === inputFragmentId
           );
 
-    const sortedFragments = filteredFragments.sort(
+    const slicedFragments = filteredFragments.slice(
+      0,
+      filteredFragments.length < TABLE_SIZE
+        ? filteredFragments.length
+        : TABLE_SIZE
+    );
+
+    const sortedFragments = slicedFragments.sort(
       (a, b) =>
         moment(b.last_updated_at).format('YYYYMMDDHHmmss') -
         moment(a.last_updated_at).format('YYYYMMDDHHmmss')

--- a/electron-app/src/components/molecules/ReportTool/LeaderSchedules/LeaderSchedules.jsx
+++ b/electron-app/src/components/molecules/ReportTool/LeaderSchedules/LeaderSchedules.jsx
@@ -13,6 +13,7 @@ import { getLeaderSchedules } from '../../../../utils/api';
 
 const LeaderSchedules = ({ nodeAddress }) => {
   const PAGE_SIZE = 8;
+  const TABLE_SIZE = 200;
   const [leaderSchedules, setLeaderSchedules] = useState();
   const [currentPage, setCurrentPage] = useState(1);
   const [totalPages, setTotalPages] = useState(1);
@@ -36,7 +37,12 @@ const LeaderSchedules = ({ nodeAddress }) => {
   };
 
   const formatSchedules = schedules => {
-    const sortedSchedules = schedules.sort(
+    const slicedSchedules = schedules.slice(
+      0,
+      schedules.length < TABLE_SIZE ? schedules.length : TABLE_SIZE
+    );
+
+    const sortedSchedules = slicedSchedules.sort(
       (a, b) =>
         moment(b.scheduled_at_time).format('YYYYMMDDHHmmss') -
         moment(a.scheduled_at_time).format('YYYYMMDDHHmmss')


### PR DESCRIPTION
- Table for leader schedules displays up to 200 records
- Table for fragment logs displays up to 200 records 