### PR TITLE
SPM-88 - Migrate from npm to yarn

### DIFF
--- a/cli-node/.gitignore
+++ b/cli-node/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 
 **-lock.json
+**.lock
 
 **.tgz

--- a/cli-node/README.md
+++ b/cli-node/README.md
@@ -4,17 +4,17 @@
 
 In project folder run:
 ```console
-npm install
+yarn install
 ```
 
 ### Usage/Run
 
 In project folder run:
 ```console
-npm start -- [ARGS]
+yarn start [ARGS]
 ```
 
-or `npm link` and run with `spm [ARGS]`
+or `yarn link` and run with `spm [ARGS]`
 
 ARGS:
   * `settings -p <node-rest-port>` establish a connection with the local node
@@ -30,12 +30,14 @@ Once connection is established, you can run these commands:
   * `fragment-logs <fragment-id>` displays fragment logs: fragment, received, uploaded, status
       * `<fragment-id>` well formed fragment id
   * `help` displays this help message
-  * `exit` texits the CLI
+  * `exit` exits the CLI
 
 ### Building package and Installation
 
-* Install production dependencies: `npm install --production`
+* Install production dependencies: `yarn install --prod`
 
-* Create distribution package (spm-0.1.0.tgz): `npm pack`
+* Create distribution package (spm-v0.1.0.tgz): `yarn pack`
 
-* Install spm globally: `npm install -g spm-0.1.0.tgz`
+> **NOTE**: you can also omit these two previous steps by using the `build` script located in the `package.json` file by running `yarn run build`.
+
+* Install spm globally: `npm install -g spm-v0.1.0.tgz`

--- a/cli-node/package.json
+++ b/cli-node/package.json
@@ -5,6 +5,7 @@
   "main": "spm.js",
   "scripts": {
     "start": "node spm",
+    "build": "yarn install --prod && yarn pack",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [

--- a/electron-app/.gitignore
+++ b/electron-app/.gitignore
@@ -4,5 +4,6 @@ out/
 dist/
 
 **-lock.json
+**.lock
 
 public/app.js

--- a/electron-app/README.md
+++ b/electron-app/README.md
@@ -3,12 +3,40 @@
 ## Install dependencies
 
 - Use nodejs v10.16.3: `nvm install 10.16.3 && nvm alias default 10.16.3`
-- Node dependencies: `npm install`
+- Node dependencies: `yarn install`
 
 ## Run Development Build
 
 In project folder run:
 
 ```console
-npm start
+yarn start
 ```
+
+## Build installers
+
+#### Build installers for your current OS
+
+In project folder run:
+
+```console
+yarn run dist
+```
+
+#### Build installers for Linux (.deb, .rpm, .AppImage, .snap)
+
+In project folder run:
+
+```console
+yarn run dist:linux
+```
+
+#### Build installers for Windows (.zip)
+
+In project folder run:
+
+```console
+yarn run dist:win
+```
+
+The installers can be found in the `dist` folder

--- a/electron-app/package.json
+++ b/electron-app/package.json
@@ -16,12 +16,12 @@
     "start:electron": "electron . --disable-gpu",
     "start:react": "webpack-dev-server --config ./webpack.config.js --mode development",
     "bundle:react": "webpack --mode production",
-    "dist": "npm run \"bundle:react\" && electron-builder",
+    "dist": "yarn run \"bundle:react\" && electron-builder",
     "eslint": "./node_modules/eslint/bin/eslint.js . --ext .jsx --ext .js",
-    "dist:win": "npm run \"bundle:react\" && electron-builder -w",
-    "dist:linux": "npm run \"bundle:react\" && electron-builder -l",
-    "dist:mac": "npm run \"bundle:react\" && electron-builder -m",    
-    "dist:all": "npm run \"bundle:react\" && electron-builder -wml"
+    "dist:win": "yarn run \"bundle:react\" && electron-builder -w",
+    "dist:linux": "yarn run \"bundle:react\" && electron-builder -l",
+    "dist:mac": "yarn run \"bundle:react\" && electron-builder -m",
+    "dist:all": "yarn run \"bundle:react\" && electron-builder -wml"
   },
   "build": {
     "appId": "io.iohk.spm",
@@ -67,7 +67,7 @@
       "category": "Development"
     },
     "win": {
-      "target": { 
+      "target": {
         "target": "zip",
         "arch": [
           "x64",
@@ -98,14 +98,14 @@
     "eslint-plugin-promise": "4.1.1",
     "eslint-plugin-react": "7.13.0",
     "less-loader": "5.0.0",
-    "npm-run-all": "4.1.5",
     "prettier": "1.17.0",
     "react-hot-loader": "4.3.11",
     "sass-loader": "8.0.0",
     "style-loader": "1.0.0",
     "webpack": "4.40.2",
     "webpack-cli": "3.1.2",
-    "webpack-dev-server": "3.1.11"
+    "webpack-dev-server": "3.1.11",
+    "yarn-run-all": "3.1.1"
   },
   "dependencies": {
     "antd": "3.25.1",


### PR DESCRIPTION
* Updated `.gitignore` to include files ended with `.lock`
* Updated the scripts in `package.json` to make use of `yarn` instead of `npm`
* Updated the instructions in the `README.md` file to use `yarn` instead of `npm`