### PR TITLE
SPM-97 - MacOS signing configuration

### DIFF
--- a/electron-app/README.md
+++ b/electron-app/README.md
@@ -15,6 +15,8 @@ yarn start
 
 ## Build installers
 
+> All installers can be found in the `dist` folder
+
 #### Build installers for your current OS
 
 In project folder run:
@@ -39,4 +41,65 @@ In project folder run:
 yarn run dist:win
 ```
 
-The installers can be found in the `dist` folder
+> On a Linux environment `yarn run dist:wl` can be run to build both Linux and Windows installers at once.
+
+#### Build and sign application for macOS (.app)
+
+> NOTE: This requires a valid Developer ID Application certificate and the file `electron-builder.env` properly configured
+
+In project folder run:
+
+```console
+yarn run dist:mac
+```
+
+#### Build and sign the macOS installer (.pkg)
+
+> NOTE: This requires a valid Developer ID Installer certificate
+
+Package `.app` directory into a `.pkg` file:
+
+```console
+pkgbuild --install-location /Applications --component dist/mac/Stake\ Pool\ Management.app dist/SPM-unsigned.pkg
+```
+
+Sign the `.pkg` file with a Developer ID Installer certificate:
+
+```console
+productsign -s "<certificate name>" dist/SPM-unsigned.pkg dist/Stake\ Pool\ Management-0.1.0.pkg
+```
+
+You can check if the package was correctly signed with:
+
+```console
+pkgutil --check-signature dist/Stake\ Pool\ Management-0.1.0.pkg
+```
+
+#### Notarize the macOS installer (.pkg)
+
+Submit package to notarize:
+
+```console 
+xcrun altool --notarize-app -f dist/Stake\ Pool\ Management-0.1.0.pkg --primary-bundle-id io.iohk.spm -u <apple-developer-username> -p <password>
+```
+
+If it was uploaded successfully the last command will return a `RequestUUID` token, copy it and use it with the following command to get the notarization status:
+
+```console
+xcrun altool --notarization-info <request-uuid> -u <apple-developer-username> -p <password>
+```
+
+Once it succeeds, staple and validate the noratization to the `.pkg`:
+
+```console
+xcrun stapler staple dist/Stake\ Pool\ Management-0.1.0.pkg
+```
+```console
+xcrun stapler validate dist/Stake\ Pool\ Management-0.1.0.pkg
+```
+
+You can check if the notarization was successful running:
+
+```console
+spctl -a -v -t install dist/Stake\ Pool\ Management-0.1.0.pkg 
+```

--- a/electron-app/electron-builder.env
+++ b/electron-app/electron-builder.env
@@ -1,0 +1,11 @@
+# HTTPS link (or base64-encoded data, or file:// link, or local path) to certificate (*.p12 or *.pfx file).
+# Shorthand ~/ is supported (home directory). Do not use together with CSC_NAME 
+CSC_LINK=file://cert.p12
+
+# The password to decrypt the certificate given in CSC_LINK.
+CSC_KEY_PASSWORD=password
+
+# macOS-only Name of certificate (to retrieve from login.keychain). 
+# Useful on a development machine (not on CI) if you have several identities (otherwise don’t specify it).
+# Do not use together with CSC_LINK
+# CSC_NAME=

--- a/electron-app/electron-builder.yaml
+++ b/electron-app/electron-builder.yaml
@@ -1,7 +1,10 @@
 ---
 appId: io.iohk.spm
 mac:
-  target: pkg
+  target: zip
+  type: distribution
+  hardenedRuntime: true
+  entitlements: entitlements.mac.inherit.plist
 linux:
   target:
   - target: deb

--- a/electron-app/entitlements.mac.inherit.plist
+++ b/electron-app/entitlements.mac.inherit.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
- Add `electron-builder.env` configuration file
- Modify mac build in `electron-builder.yaml` configuration file
- Update `README.md` with mac signing instructions
- Add `entitlements.mac.inherit.plist` entitlement file